### PR TITLE
Fix Vite dev proxy to use local backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# Load Testing System Frontend
+
+## Local Development
+
+- Start the Express backend on port **4000**.
+- (Optional) Set `VITE_API_PROXY_TARGET` to override the default proxy target.
+- Run `npm run dev` from `frontend_src` to start the Vite dev server. The `/api` proxy will forward to `http://localhost:4000` by default.

--- a/frontend_src/vite.config.ts
+++ b/frontend_src/vite.config.ts
@@ -1,15 +1,18 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const backendTarget = process.env.VITE_API_PROXY_TARGET || 'http://localhost:4000'
+const isHttpsTarget = backendTarget.startsWith('https://')
+
 export default defineConfig({
   plugins: [react()],
   server: {
     port: 3000,
     proxy: {
       '/api': {
-        target: 'https://ftc-compliance.us',
-        changeOrigin: true,
-        secure: true
+        target: backendTarget,
+        changeOrigin: isHttpsTarget,
+        secure: isHttpsTarget
       }
     }
   },


### PR DESCRIPTION
## Summary
- point the Vite dev proxy at a configurable backend that defaults to http://localhost:4000
- update proxy options so changeOrigin/secure follow the protocol and add backend documentation for contributors

## Testing
- npm run dev -- --host 0.0.0.0
- curl -s http://localhost:3000/api/test

------
https://chatgpt.com/codex/tasks/task_e_68effe66a5c0832598fdf62197e66226