### PR TITLE
Support configurable API base URL

### DIFF
--- a/DEPLOYMENT_AND_SCALING_INSTRUCTIONS.md
+++ b/DEPLOYMENT_AND_SCALING_INSTRUCTIONS.md
@@ -58,6 +58,15 @@ npm install
 npm run build
 ```
 
+### API Base URL Configuration
+- By default the production build issues requests to the backend using the relative path `/api`, which allows the frontend and PHP API to be hosted from the same origin.
+- When the API is deployed to a different host or path, provide an explicit override at build time:
+  ```bash
+  VITE_API_BASE_URL="https://api.example.com/load-testing" npm run build
+  ```
+- Any value supplied through `VITE_API_BASE_URL` is normalised to avoid duplicate slashes and can point to either an absolute URL or a relative path such as `/backend`.
+- Make sure your reverse proxy or web server forwards the chosen path to the PHP endpoints (for example, proxying `/api` to the `api/` directory) so the relative URLs resolve correctly.
+
 ### FTP Deployment Script
 ```python
 #!/usr/bin/env python3

--- a/frontend_src/src/api/api.ts
+++ b/frontend_src/src/api/api.ts
@@ -13,8 +13,21 @@ import type {
   StopTestRequest
 } from './types';
 
+const envBaseURL = import.meta.env.VITE_API_BASE_URL?.trim();
+const normalizeBaseURL = (url: string): string => {
+  const trimmed = url.replace(/\/+$/, '');
+  if (/^https?:\/\//i.test(trimmed) || trimmed.startsWith('//')) {
+    return trimmed;
+  }
+  return trimmed.startsWith('/') ? trimmed : `/${trimmed}`;
+};
+
+const normalizedBaseURL = envBaseURL && envBaseURL.length > 0
+  ? normalizeBaseURL(envBaseURL)
+  : '/api';
+
 const api = axios.create({
-  baseURL: '/api',
+  baseURL: normalizedBaseURL,
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend_src/src/vite-env.d.ts
+++ b/frontend_src/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+declare interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+  [key: string]: string | undefined;
+}
+
+declare interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- default the axios client to the relative /api path while allowing overrides through VITE_API_BASE_URL
- add Vite environment type definitions for the new variable
- document how to point the frontend at an alternate API host or path

## Testing
- npm run build
- npm run preview -- --host 0.0.0.0 --port 4173 (followed by curl smoke tests of /dashboard, /targets, /runs, /reports)


------
https://chatgpt.com/codex/tasks/task_e_68effe640f3c832598fc1ac2761075fe