### PR TITLE
Make frontend API base URL configurable

### DIFF
--- a/DEPLOYMENT_AND_SCALING_INSTRUCTIONS.md
+++ b/DEPLOYMENT_AND_SCALING_INSTRUCTIONS.md
@@ -58,6 +58,13 @@ npm install
 npm run build
 ```
 
+### API Base URL Configuration
+
+- By default, the frontend expects the PHP API to be available under the same origin at the relative path `/api`, which aligns with the repository's production bundle in `deployment_ready/`.
+- If your API is hosted on a different domain or subdomain, define a `VITE_API_BASE_URL` environment variable (or add it to an `.env` file) before running `npm run build`/`npm run dev`.
+- Example: `VITE_API_BASE_URL=https://api.your-domain.com` will cause the UI to make requests such as `https://api.your-domain.com/health_endpoint.php`.
+- When reverse proxying, ensure the web server forwards `/api/*` requests to the backend while continuing to serve the static frontend assets from the same origin for the default configuration to work.
+
 ### FTP Deployment Script
 ```python
 #!/usr/bin/env python3

--- a/frontend_src/src/api/api.ts
+++ b/frontend_src/src/api/api.ts
@@ -13,8 +13,21 @@ import type {
   StopTestRequest
 } from './types';
 
+const resolveBaseURL = (): string => {
+  const envBaseUrl = import.meta.env.VITE_API_BASE_URL;
+  if (typeof envBaseUrl === 'string') {
+    const trimmed = envBaseUrl.trim();
+    if (trimmed.length > 0) {
+      const sanitized = trimmed.replace(/\/+$/, '');
+      return sanitized.length > 0 ? sanitized : '/';
+    }
+  }
+
+  return '/api';
+};
+
 const api = axios.create({
-  baseURL: '/api',
+  baseURL: resolveBaseURL(),
   timeout: 30000,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend_src/src/vite-env.d.ts
+++ b/frontend_src/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare interface ImportMetaEnv {
+  readonly VITE_API_BASE_URL?: string;
+}
+
+declare interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- default frontend API client now reads `VITE_API_BASE_URL` when provided and falls back to the same-origin `/api` path
- added Vite environment type definitions so TypeScript recognises the new configuration variable
- documented how to override the API base URL and how to proxy `/api` requests when serving the UI and PHP backend together

## Testing
- npm run build
- python smoke test script exercising Dashboard, Targets, Runs, and Reports against the production build with mocked API responses

------
https://chatgpt.com/codex/tasks/task_e_68effe6785d88325bbb0f6c9243418a8